### PR TITLE
add auth support for other types of users

### DIFF
--- a/workfindr/server/auth.js
+++ b/workfindr/server/auth.js
@@ -49,9 +49,13 @@ async function phpAuth(req, res, next) {
 
     const loggedIn = await fetchResp.json();
 
-    if (loggedIn.logged_in && loggedIn.user_id != null) {
+    if (loggedIn.logged_in) {
       // put user information in the request
-      req.user = { id: loggedIn.user_id };
+      req.user = {
+        id: loggedIn.user_id,
+        recruiter: loggedIn.recruiter_id,
+        admin: loggedIn.admin_id,
+      };
     }
     next();
   } catch (e) {
@@ -60,7 +64,7 @@ async function phpAuth(req, res, next) {
 }
 
 function requireValidUser(req, res, next) {
-  if (!req.user) {
+  if (!req.user || req.user.id == null) {
     res.sendStatus(401);
   } else {
     next();


### PR DESCRIPTION
Changes auth logic so we know the user is logged in but not as a normal user. Then the client can:

- [x] on splash page request ./user-id and not ./user or ./user/id
- [x] then if the user is logged in but doesn't have a user id, it should say that only normal users (and not recruiters or admins) count in career guide
