### PR TITLE
Maps guest accounts

### DIFF
--- a/maps-api/README.md
+++ b/maps-api/README.md
@@ -154,7 +154,23 @@ Any registered user can request their map pins at `<root>[/v2]/pins`; if they ha
 
 _NB: The login API call is only for checking role and training centres and is not required; there are no sessions and every API request contains the credentials._
 
+#### Guest accounts (read-only users)
 
+Some user accounts (with the internal role of _user_) can be restricted to be read-only, i.e. not allowing and updates. These then serve as _guest accounts_ for the purpose of a public service.
+
+* an account can be restricted by setting `visible` in the `users` table to `false`
+* we could instead add a column in the `users` table
+* we could extend tables under our control:
+  - `training_centre_assignments` – a user could be marked as restricted when assigned to some training centre
+    * only users assigned to training centres can be restricted
+    * we have to check training centre assignments to authorize any updates
+  - `user_map_pins_v2` – a user could have a special pin that restricts them
+    * any user could be restricted
+    * a user could possibly even restrict themselves
+    * we have to check pins to authorize any updates
+  - add `user_restrictions` – a user could have a restriction in there
+
+* the API /login needs to report a new role: `readonly_user`
 
 
 ## Assumptions

--- a/maps-api/README.md
+++ b/maps-api/README.md
@@ -121,7 +121,7 @@ These routes return `403 Forbidden` if the current user is not a normal user (i.
 * GET `<root>[/v2]/login` – (optional) returns information about the user, in the following format:
   ```
   {
-    role:                "user" or "recruiter",
+    role:                "user" or "recruiter" or "guest",
     training_centres: [
       {
         email:           String,
@@ -137,6 +137,7 @@ These routes return `403 Forbidden` if the current user is not a normal user (i.
   - notes
     - in pontoonapps, training centres have "recruiter" role;
     - `training_centres` is there only if the role is "user"; if the user is not assigned to any training centre, it will be an empty array.
+    - `guest` is a user assigned to a training centre who can see the training centre's pins but does not have any pins of their own.
 
 ### Authentication
 
@@ -148,10 +149,13 @@ If your key is ABCDEFGH, you can check the API at https://pontoonapps.com/commun
 
 Users in the app use their pontoonapps.com account details: the API accepts pontoonapps.com "job seekers" (internally under the role _user_) and "recruiters".
 
-The app uses these account details (email and password) with **HTTP Basic Authentication** in all API requests (except `ping`). Without valid credentials, the API returns 401 Unauthorized.
 The API accepts two forms of credentials: HTTP Basic with email and password, and a PHP session ID in a cookie for web-based login.
 
 1. The main site's PHP session cookie can tie the user to an account. Otherwise, the following auth options apply.
+
+2. Special auth credentials for a guest user for a given training centre, sent through HTTP Basic Authentication as discussed below.
+  - username: "guest_account"             
+  - password: _the email address of the training centre_
 
 3. The app can get account details (email and password) with **HTTP Basic Authentication** in all API requests (except `ping`). Without valid credentials, the API returns 401 Unauthorized.
 

--- a/maps-api/README.md
+++ b/maps-api/README.md
@@ -28,7 +28,9 @@ The main routes are:
 
 ### Map Pin routes
 
-* GET `<root>/v2/pins` – return array of all pins visible to this user
+Guest accounts only have access to the GET route.
+
+* GET `<root>/v2/pins` – return array of all pins visible to this user or guest account
 * POST `<root>/v2/pins` – add a user pin (accepts JSON)
   * if the JSON includes an ID, this is an update operation (existence of that ID among this user's pins is checked)
   * if the JSON does not include an ID, this is an add operation (creates a new pin)
@@ -45,7 +47,7 @@ The main routes are:
 
 Original (v1) API:
 
-* GET `<root>/pins` – return array of all pins visible to this user
+* GET `<root>/pins` – return array of all pins visible to this user or guest account
 * POST `<root>/pins` – add a user pin (accepts JSON)
   * if the user already has a pin with this name, the pin information is all updated
   * returns 204 No Content on success
@@ -105,7 +107,7 @@ These routes return `403 Forbidden` if the current user is not a training centre
 
 (v1 and v2 APIs are the same, the `/v2` part of the URL is optional)
 
-These routes return `403 Forbidden` if the current user is not a normal user (i.e. if they are a training centre).
+These routes return `403 Forbidden` if the current user is not a normal user (i.e. if they are a training centre or a guest account).
 
 * GET `<root>[/v2]/user/training-centres` – return array of training centres of the given user (same data structure as in `training_centres` at `<root>/login` below)
 * POST `<root>[/v2]/user/training-centres/remove` – remove the calling user from the given training centre (accepts JSON)
@@ -122,7 +124,7 @@ These routes return `403 Forbidden` if the current user is not a normal user (i.
   ```
   {
     role:                "user" or "recruiter" or "guest",
-    training_centres: [
+    training_centres: [  // optional
       {
         email:           String,
         name: {

--- a/maps-api/README.md
+++ b/maps-api/README.md
@@ -149,6 +149,11 @@ If your key is ABCDEFGH, you can check the API at https://pontoonapps.com/commun
 Users in the app use their pontoonapps.com account details: the API accepts pontoonapps.com "job seekers" (internally under the role _user_) and "recruiters".
 
 The app uses these account details (email and password) with **HTTP Basic Authentication** in all API requests (except `ping`). Without valid credentials, the API returns 401 Unauthorized.
+The API accepts two forms of credentials: HTTP Basic with email and password, and a PHP session ID in a cookie for web-based login.
+
+1. The main site's PHP session cookie can tie the user to an account. Otherwise, the following auth options apply.
+
+3. The app can get account details (email and password) with **HTTP Basic Authentication** in all API requests (except `ping`). Without valid credentials, the API returns 401 Unauthorized.
 
 Any registered user can request their map pins at `<root>[/v2]/pins`; if they have never submitted any, this will return an empty array.
 
@@ -156,21 +161,10 @@ _NB: The login API call is only for checking role and training centres and is no
 
 #### Guest accounts (read-only users)
 
-Some user accounts (with the internal role of _user_) can be restricted to be read-only, i.e. not allowing and updates. These then serve as _guest accounts_ for the purpose of a public service.
+A _guest account_ is a special set of authentication credentials that represents a read-only user tied to one training centre. This then serves the purpose of a public service.
 
-* an account can be restricted by setting `visible` in the `users` table to `false`
-* we could instead add a column in the `users` table
-* we could extend tables under our control:
-  - `training_centre_assignments` – a user could be marked as restricted when assigned to some training centre
-    * only users assigned to training centres can be restricted
-    * we have to check training centre assignments to authorize any updates
-  - `user_map_pins_v2` – a user could have a special pin that restricts them
-    * any user could be restricted
-    * a user could possibly even restrict themselves
-    * we have to check pins to authorize any updates
-  - add `user_restrictions` – a user could have a restriction in there
-
-* the API /login needs to report a new role: `readonly_user`
+* this is stored in the table `training_centre_features` that tells us whether a training centre has enabled a guest account
+* we would later need a way for a training centre to enable/disable their guest account (by default disabled, enabled manually in the DB for the special user requesting this feature)
 
 
 ## Assumptions

--- a/maps-api/api/auth/basic.js
+++ b/maps-api/api/auth/basic.js
@@ -18,12 +18,24 @@ module.exports = () => {
 };
 
 async function checkDBUser(user, pwd, authObj) {
-  const userRole = await db.findUserRole(user, pwd);
-  if (userRole != null) {
-    authObj.id = userRole.id;
-    authObj.role = userRole.role;
-    return true;
+  if (user === 'guest_account') {
+    // find whether the password identifies a guest-account-enabled training centre
+    const trainingCentre = await db.findGuestAccount(pwd);
+    if (trainingCentre != null) {
+      authObj.role = 'guest';
+      authObj.trainingCentreID = trainingCentre;
+      return true;
+    } else {
+      return false;
+    }
   } else {
-    return false;
+    const userRole = await db.findUserRole(user, pwd);
+    if (userRole != null) {
+      authObj.id = userRole.id;
+      authObj.role = userRole.role;
+      return true;
+    } else {
+      return false;
+    }
   }
 }

--- a/maps-api/api/v1-and-v2.js
+++ b/maps-api/api/v1-and-v2.js
@@ -27,7 +27,7 @@ async function getUserPins(req, res, next) {
       res.json(await db.listTrainingCentrePins(req.auth.id));
       break;
     case 'guest':
-      res.json(await db.listTrainingCentrePins(req.auth.trainingCentreID));
+      res.json(await db.listGuestAccountPins(req.auth.trainingCentreID));
       break;
     default:
       res.status(403).send('unrecognized user role');

--- a/maps-api/api/v1-and-v2.js
+++ b/maps-api/api/v1-and-v2.js
@@ -26,6 +26,9 @@ async function getUserPins(req, res, next) {
     case 'recruiter':
       res.json(await db.listTrainingCentrePins(req.auth.id));
       break;
+    case 'guest':
+      res.json(await db.listTrainingCentrePins(req.auth.trainingCentreID));
+      break;
     default:
       res.status(403).send('unrecognized user role');
   }

--- a/maps-api/db/index.js
+++ b/maps-api/db/index.js
@@ -92,8 +92,20 @@ async function listTrainingCentrePins(tcId) {
   return extractPinInfo(rows);
 }
 
+async function listGuestAccountPins(tcId) {
+  const sql = await dbConn;
+  const query = `SELECT id, name, category, description, phone, website,
+                        email, address_line_1, address_line_2,
+                        postcode, latitude, longitude, notes
+                 FROM training_centre_map_pins_v2
+                 WHERE training_centre_id = ?`;
+  const [rows] = await sql.query(query, [tcId]);
 
-function extractPinInfo(rows) {
+  return extractPinInfo(rows, true);
+}
+
+
+function extractPinInfo(rows, guest = false) {
   const pins = [];
   for (const row of rows) {
     const pin = {};
@@ -117,8 +129,8 @@ function extractPinInfo(rows) {
     if (row.tc_email != null) pin.training_centre_email = row.tc_email;
     /* eslint-enable no-multi-spaces */
 
-    // userPin is always there
-    pin.userPin = row.tc_email == null;
+    // the property userPin is always there
+    pin.userPin = guest ? false : row.tc_email == null;
   }
   return pins;
 }
@@ -454,6 +466,7 @@ module.exports = {
   v1v2: {
     listUserPins,
     listTrainingCentrePins,
+    listGuestAccountPins,
     findUserTrainingCentres,
     listTrainingCentreUsers,
     updateTrainingCentreUsers,

--- a/maps-api/db/index.js
+++ b/maps-api/db/index.js
@@ -423,12 +423,13 @@ async function findGuestAccount(email) {
                    FROM recruiters r
                    JOIN training_centre_features f
                      ON r.id = f.training_centre_id
-                   WHERE r.email = ?`;
+                   WHERE r.email = ?
+                     AND has_guest_account`;
 
     const [rows] = await sql.query(query, [email]);
 
     if (rows.length > 0) {
-      return rows[0].id;
+      return rows[0].training_centre_id;
     } else {
       return null;
     }

--- a/maps-api/db/index.js
+++ b/maps-api/db/index.js
@@ -412,6 +412,31 @@ async function removeUserFromTrainingCentre(userId, tcEmail) {
   return rows.affectedRows > 0;
 }
 
+/*
+ * finds the training centre identified by the given email
+ * but only if it has guest accounts enabled, then return its ID
+ */
+async function findGuestAccount(email) {
+  try {
+    const sql = await dbConn;
+    const query = `SELECT training_centre_id
+                   FROM recruiters r
+                   JOIN training_centre_features f
+                     ON r.id = f.training_centre_id
+                   WHERE r.email = ?`;
+
+    const [rows] = await sql.query(query, [email]);
+
+    if (rows.length > 0) {
+      return rows[0].id;
+    } else {
+      return null;
+    }
+  } catch (e) {
+    return null;
+  }
+}
+
 module.exports = {
   v1: {
     addUpdateUserPin: addUpdateUserPinV1,
@@ -435,5 +460,6 @@ module.exports = {
   },
   common: {
     findUserRole,
+    findGuestAccount,
   },
 };

--- a/maps-api/db/migrations/002-add-training-centre-features.sql
+++ b/maps-api/db/migrations/002-add-training-centre-features.sql
@@ -1,0 +1,6 @@
+CREATE TABLE training_centre_features (
+  training_centre_id INT             NOT NULL,
+  has_guest_account  BOOLEAN         NOT NULL DEFAULT 0,
+  FOREIGN KEY (training_centre_id) REFERENCES recruiters(id),
+  PRIMARY KEY (training_centre_id)
+)

--- a/maps-api/db/sql-init.sql
+++ b/maps-api/db/sql-init.sql
@@ -42,3 +42,10 @@ CREATE TABLE training_centre_assignments (
   FOREIGN KEY (training_centre_id) REFERENCES recruiters(id),
   PRIMARY KEY (user_id, training_centre_id)
 );
+
+CREATE TABLE training_centre_features (
+  training_centre_id INT             NOT NULL,
+  has_guest_account  BOOLEAN         NOT NULL DEFAULT 0,
+  FOREIGN KEY (training_centre_id) REFERENCES recruiters(id),
+  PRIMARY KEY (training_centre_id)
+)


### PR DESCRIPTION
implements guest accounts for training centres;

todo: for now, enabling guest accounts for training centres is done manually by adding the right row in the `training_centre_features` table; we may want an API route and a UI so that training centres can enable/disable their guest accounts.